### PR TITLE
Cytoscape z-index: 400

### DIFF
--- a/cytoscape-leaf.css
+++ b/cytoscape-leaf.css
@@ -1,3 +1,7 @@
+.__________cytoscape_container {
+  z-index: 400;
+}
+
 .cy-leaflet-toggle {
   position: absolute;
   /* left: 0; */


### PR DESCRIPTION
"New" cytoscape_container class added (in fact it's not new, cytoscape uses it automatically on cytoscape container) with z-index: 400. It fixes "hiding" behind leaflet panes - in leflaet z-index: 400 is assigned to overlay - so graph will be treated as leaflet overlay. 